### PR TITLE
同步 Desktop 未发布版本边界

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Development version `0.4.0-dev`. Not a GitHub Release.
 - Status states: `not-installed`, `active-aligned`, `inactive`, `drift`, `conflict`, `recovery-required`.
 - `--restore-hooks` restores only hooks owned by the current manifest.
 - Fresh `config.toml` always receives a marked compat block.
+- Desktop top-level navigation now focuses on Status, Deploy, Manage, and Settings; Run and Test live under an opt-in Advanced tools entry, with legacy deep links preserved.
+- Desktop status, deploy, manage, and diagnostics surfaces now use user-facing summaries with raw plans, identifiers, and diagnostics available only through collapsed technical details.
 
 ### Docs
 
@@ -35,6 +37,8 @@ Development version `0.4.0-dev`. Not a GitHub Release.
 - `GROK_KEYSMIth_CONTRACT` is only a deprecated alias of `GROK_KEYSMITH_CONTRACT`.
 - Historical breaktest scripts no longer hardcode a user home path.
 - Windows checks use canonical paths and LF prompt bytes; native `grok.exe` is preferred and `.cmd` / `.bat` override launches fail with an actionable diagnostic.
+- Desktop write actions are gated by managed, hook-ownership, drift/conflict, and interrupted-transaction state while preserving fresh preview binding, exclusive operation leases, and post-write verification.
+- Diagnostic export recursively redacts local absolute paths, and the GUI audit now covers 43 responsive, theme, failure, confirmation, recovery, diagnostics, and legacy-navigation scenarios.
 
 ## [Desktop 0.1.0-beta.1] - 2026-08-14
 

--- a/README.en.md
+++ b/README.en.md
@@ -44,6 +44,8 @@ The Keysmith series **deploys, verifies, and revokes** custom instructions for l
 1. **Conservative: stable CLI.** Use the verified single file from the [latest stable Release](https://github.com/Jia-Ethan/grok-keysmith/releases/latest) (currently `v0.3.0`), or check out the same tag. That build has neither `--json` nor `--grok-dir`. Do not treat floating `main` (`0.4.0-dev`) as the stable install.
 2. **Easier: unsigned Desktop Beta.** See [desktop-v0.1.0-beta.1](https://github.com/Jia-Ethan/grok-keysmith/releases/tag/desktop-v0.1.0-beta.1): macOS Apple Silicon DMG and Windows x64 NSIS, embedding a development CLI sidecar. No signing, no auto-update, no Linux GUI.
 
+The latest published Desktop remains beta.1. `main` contains information-architecture and workflow improvements for the next Desktop beta: top-level navigation is limited to Status, Deploy, Manage, and Settings; Run/Test move into an opt-in Advanced tools view; status and diagnostics use user summaries with technical details on demand. These changes are not versioned or published yet; formal installers must be rebuilt from a new final version commit or tag.
+
 ### Quick start
 
 **Release single file (recommended):**

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Keysmith 系列为本地 AI 工具**安全部署、验证和撤销**自定义指
 1. **稳妥：稳定 CLI。** 使用 [最新稳定 Release](https://github.com/Jia-Ethan/grok-keysmith/releases/latest)（当前 `v0.3.0`）的已校验单文件，或 checkout 同一 tag。该版本没有 `--json` / `--grok-dir`。不要从浮动 `main`（`0.4.0-dev`）当稳定版安装。
 2. **更易用：未签名 Desktop Beta。** 见 [desktop-v0.1.0-beta.1](https://github.com/Jia-Ethan/grok-keysmith/releases/tag/desktop-v0.1.0-beta.1)：macOS Apple Silicon DMG 与 Windows x64 NSIS，内嵌开发版 CLI sidecar。无签名、无自动更新、无 Linux GUI。
 
+已发布的 Desktop 仍是 beta.1。`main` 已包含下一版 Desktop 的信息架构与操作流程改进：首层导航收敛为状态、部署、管理和设置，运行/测试移入默认关闭的高级工具，状态与诊断改为用户摘要加按需技术详情。这些变化尚未版本化或发布；正式安装包必须从新的最终版本提交或 tag 重新构建。
+
 ### 快速开始
 
 **Release 单文件（推荐）：**

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -158,7 +158,7 @@ grok-keysmith/
 ├── grok-unrestricted.sh/.ps1     # Runner 包装
 ├── examples/grok-unrestricted.md
 ├── tests/                        # 隔离 HOME / fake Grok 测试
-├── gui/                          # Desktop 0.1.0-beta.1
+├── gui/                          # Desktop source (published beta.1; next beta changes on main)
 ├── VERSION
 ├── docs/
 ├── README.md / README.en.md

--- a/gui/README.md
+++ b/gui/README.md
@@ -2,6 +2,8 @@
 
 Version `0.1.0-beta.1` is published as [`desktop-v0.1.0-beta.1`](https://github.com/Jia-Ethan/grok-keysmith/releases/tag/desktop-v0.1.0-beta.1). The Release provides an ad-hoc-signed macOS Apple Silicon DMG, an unsigned Windows x64 current-user NSIS installer, and `SHA256SUMS`.
 
+The source on `main` is ahead of that published beta: top-level navigation is limited to Status, Deploy, Manage, and Settings; Run/Test are available through an opt-in Advanced tools view; user summaries replace raw technical data on primary surfaces. These post-beta.1 changes are not released until a new version and tag are built from the final version commit.
+
 - macOS: `grok-keysmith_0.1.0-beta.1_aarch64.dmg`
 - Windows: `grok-keysmith_0.1.0-beta.1_x64-setup.exe`
 

--- a/gui/SPEC.md
+++ b/gui/SPEC.md
@@ -1,6 +1,6 @@
 # grok-keysmith GUI
 
-Desktop 0.1.0-beta.1 wraps the Python CLI. The UI never writes `~/.grok` itself.
+The current Desktop source wraps the Python CLI. The latest published Desktop is `0.1.0-beta.1`; post-beta.1 changes on `main` remain unversioned and unreleased. The UI never writes `~/.grok` itself.
 
 Stack: Tauri 2 + React 19 + Tailwind 4 + Radix + Motion + PyInstaller sidecar `grok-keysmith-cli`.
 


### PR DESCRIPTION
## 改动

- 在双语 README 中明确已发布 Desktop 仍为 beta.1，`main` 的界面与流程优化尚未版本化或发布
- 在 Changelog、GUI README、GUI SPEC 与 reference 中同步当前 Desktop 信息架构、状态门禁和诊断脱敏边界
- 保留 beta.1 Release 文档的历史事实，不把 PR 构建产物误写成正式发布证据

## 验证

- `git diff --check`
- 文档路径和版本边界核验
- 敏感信息与相对时间扫描
- 基于最新 `main@2105c207a1d3d6e173dd2a4bc719ab545f8e28a7`
