### PR TITLE
修正 v0.4.0 完整包安装路径

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -41,23 +41,24 @@ The Keysmith series **deploys, verifies, and revokes** custom instructions for l
 
 ### Install options
 
-1. **Conservative: stable CLI.** Use the verified single file from the [latest stable Release](https://github.com/Jia-Ethan/grok-keysmith/releases/latest) (currently `v0.4.0`), or check out the same tag. Do not install from floating `main`.
+1. **Conservative: stable CLI.** Use the complete ZIP / Tarball from the [latest stable Release](https://github.com/Jia-Ethan/grok-keysmith/releases/latest) (currently `v0.4.0`), or check out the same tag. `run` and `breaktest` require sibling modules, so do not download only `grok-keysmith.py` or install from floating `main`.
 2. **Easier: unsigned Desktop Beta.** See [desktop-v0.1.0-beta.2](https://github.com/Jia-Ethan/grok-keysmith/releases/tag/desktop-v0.1.0-beta.2): macOS Apple Silicon DMG and Windows x64 NSIS, embedding the stable `0.4.0` CLI sidecar. No developer signing, no auto-update, no Linux GUI.
 
 ### Quick start
 
-**Release single file (recommended):**
+**Release ZIP (recommended):**
 
 ```bash
-mkdir grok-keysmith-v0.4.0 && cd grok-keysmith-v0.4.0
-curl -LO https://github.com/Jia-Ethan/grok-keysmith/releases/download/v0.4.0/grok-keysmith-v0.4.0.py
+curl -LO https://github.com/Jia-Ethan/grok-keysmith/releases/download/v0.4.0/grok-keysmith-v0.4.0.zip
 curl -LO https://github.com/Jia-Ethan/grok-keysmith/releases/download/v0.4.0/SHA256SUMS
-grep ' grok-keysmith-v0.4.0.py$' SHA256SUMS | shasum -a 256 -c -
-python3 grok-keysmith-v0.4.0.py --version
-python3 grok-keysmith-v0.4.0.py --status
-python3 grok-keysmith-v0.4.0.py --dry-run
+grep ' grok-keysmith-v0.4.0.zip$' SHA256SUMS | shasum -a 256 -c -
+unzip grok-keysmith-v0.4.0.zip
+cd grok-keysmith-v0.4.0
+python3 grok-keysmith.py --version
+python3 grok-keysmith.py --status
+python3 grok-keysmith.py --dry-run
 # After reviewing the ~/.grok target, prompt, and isolation plan:
-python3 grok-keysmith-v0.4.0.py --yes
+python3 grok-keysmith.py --yes
 ```
 
 **Pinned source tag:**
@@ -85,13 +86,11 @@ python3 grok-keysmith.py --yes
 
 ### How to undo
 
-The commands below use the Release single file. For a tag checkout, replace the filename with `grok-keysmith.py`.
-
 ```bash
-python3 grok-keysmith-v0.4.0.py --restore-hooks        # Preview the hooks restore plan
-python3 grok-keysmith-v0.4.0.py --restore-hooks --yes  # Restore hooks
-python3 grok-keysmith-v0.4.0.py --uninstall            # Preview the full uninstall
-python3 grok-keysmith-v0.4.0.py --uninstall --yes      # Run the full uninstall
+python3 grok-keysmith.py --restore-hooks        # Preview the hooks restore plan
+python3 grok-keysmith.py --restore-hooks --yes  # Restore hooks
+python3 grok-keysmith.py --uninstall            # Preview the full uninstall
+python3 grok-keysmith.py --uninstall --yes      # Run the full uninstall
 ```
 
 For an interrupted transaction, run `--status`, preview with `--recover`, then add `--yes`. v0.1.x deployments that wrote `AGENTS.md` remain uninstallable after a content-ownership check.

--- a/README.md
+++ b/README.md
@@ -41,23 +41,24 @@ Keysmith 系列为本地 AI 工具**安全部署、验证和撤销**自定义指
 
 ### 安装方式
 
-1. **稳妥：稳定 CLI。** 使用 [最新稳定 Release](https://github.com/Jia-Ethan/grok-keysmith/releases/latest)（当前 `v0.4.0`）的已校验单文件，或 checkout 同一 tag。不要从浮动 `main` 安装。
+1. **稳妥：稳定 CLI。** 使用 [最新稳定 Release](https://github.com/Jia-Ethan/grok-keysmith/releases/latest)（当前 `v0.4.0`）的完整 ZIP / Tarball，或 checkout 同一 tag。`run` 与 `breaktest` 依赖同目录模块，不要只下载 `grok-keysmith.py`，也不要从浮动 `main` 安装。
 2. **更易用：未签名 Desktop Beta。** 见 [desktop-v0.1.0-beta.2](https://github.com/Jia-Ethan/grok-keysmith/releases/tag/desktop-v0.1.0-beta.2)：macOS Apple Silicon DMG 与 Windows x64 NSIS，内嵌稳定版 `0.4.0` CLI sidecar。无开发者签名、无自动更新、无 Linux GUI。
 
 ### 快速开始
 
-**Release 单文件（推荐）：**
+**Release ZIP（推荐）：**
 
 ```bash
-mkdir grok-keysmith-v0.4.0 && cd grok-keysmith-v0.4.0
-curl -LO https://github.com/Jia-Ethan/grok-keysmith/releases/download/v0.4.0/grok-keysmith-v0.4.0.py
+curl -LO https://github.com/Jia-Ethan/grok-keysmith/releases/download/v0.4.0/grok-keysmith-v0.4.0.zip
 curl -LO https://github.com/Jia-Ethan/grok-keysmith/releases/download/v0.4.0/SHA256SUMS
-grep ' grok-keysmith-v0.4.0.py$' SHA256SUMS | shasum -a 256 -c -
-python3 grok-keysmith-v0.4.0.py --version
-python3 grok-keysmith-v0.4.0.py --status
-python3 grok-keysmith-v0.4.0.py --dry-run
+grep ' grok-keysmith-v0.4.0.zip$' SHA256SUMS | shasum -a 256 -c -
+unzip grok-keysmith-v0.4.0.zip
+cd grok-keysmith-v0.4.0
+python3 grok-keysmith.py --version
+python3 grok-keysmith.py --status
+python3 grok-keysmith.py --dry-run
 # 确认 ~/.grok 目标、提示词和 isolation 计划后：
-python3 grok-keysmith-v0.4.0.py --yes
+python3 grok-keysmith.py --yes
 ```
 
 **固定 tag 源码：**
@@ -85,13 +86,11 @@ python3 grok-keysmith.py --yes
 
 ### 如何撤销
 
-以下以 Release 单文件为例；tag checkout 请把文件名换成 `grok-keysmith.py`。
-
 ```bash
-python3 grok-keysmith-v0.4.0.py --restore-hooks        # 预览 hooks 恢复计划
-python3 grok-keysmith-v0.4.0.py --restore-hooks --yes  # 实际恢复 hooks
-python3 grok-keysmith-v0.4.0.py --uninstall            # 预览完整卸载
-python3 grok-keysmith-v0.4.0.py --uninstall --yes      # 实际执行完整卸载
+python3 grok-keysmith.py --restore-hooks        # 预览 hooks 恢复计划
+python3 grok-keysmith.py --restore-hooks --yes  # 实际恢复 hooks
+python3 grok-keysmith.py --uninstall            # 预览完整卸载
+python3 grok-keysmith.py --uninstall --yes      # 实际执行完整卸载
 ```
 
 中断事务先 `--status`，再 `--recover` 预览，确认后加 `--yes`。v0.1.x 写在 `AGENTS.md` 的旧部署仍可卸载，但会先做内容所有权校验。


### PR DESCRIPTION
修正 v0.4.0 安装说明，要求使用包含 `run` / `breaktest` 依赖模块的完整 ZIP、Tarball 或固定 tag 源码。
