### PR TITLE
发布 grok-keysmith v0.4.1 与 Desktop beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,16 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and release versions
 follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Desktop 0.1.0-beta.3] - Unreleased
+## [Desktop 0.1.0-beta.3] - 2026-08-18
+
+Third desktop pre-release for macOS Apple Silicon and Windows x64, bundling CLI `0.4.1`.
 
 ### Fixed
 
 - Repairable compat drift now exposes only the preview-confirm reconcile action; uninstall and hook restore remain gated until ownership is re-established.
 - The GUI audit covers fresh reconcile preview binding, exact confirmation-token apply, and post-write `active-aligned` verification.
 
-## [0.4.1] - Unreleased
+## [0.4.1] - 2026-08-18
 
 ### Added
 
@@ -259,8 +261,8 @@ version and does not include the earlier private-only predecessor.
 - Journal and manifest evidence protects against accidental drift and ordinary
   races, not coordinated same-user tampering.
 
-[0.4.1]: https://github.com/Jia-Ethan/grok-keysmith/compare/v0.4.0...HEAD
-[Unreleased]: https://github.com/Jia-Ethan/grok-keysmith/compare/v0.4.0...HEAD
+[0.4.1]: https://github.com/Jia-Ethan/grok-keysmith/compare/v0.4.0...v0.4.1
+[Desktop 0.1.0-beta.3]: https://github.com/Jia-Ethan/grok-keysmith/releases/tag/desktop-v0.1.0-beta.3
 [Desktop 0.1.0-beta.2]: https://github.com/Jia-Ethan/grok-keysmith/releases/tag/desktop-v0.1.0-beta.2
 [Desktop 0.1.0-beta.1]: https://github.com/Jia-Ethan/grok-keysmith/releases/tag/desktop-v0.1.0-beta.1
 [0.4.0]: https://github.com/Jia-Ethan/grok-keysmith/compare/v0.3.0...v0.4.0

--- a/README.en.md
+++ b/README.en.md
@@ -41,19 +41,19 @@ The Keysmith series **deploys, verifies, and revokes** custom instructions for l
 
 ### Install options
 
-1. **Conservative: stable CLI.** Use the complete ZIP / Tarball from the [latest stable Release](https://github.com/Jia-Ethan/grok-keysmith/releases/latest) (currently `v0.4.0`), or check out the same tag. `run` and `breaktest` require sibling modules, so do not download only `grok-keysmith.py` or install from floating `main`.
-2. **Easier: unsigned Desktop Beta.** See [desktop-v0.1.0-beta.2](https://github.com/Jia-Ethan/grok-keysmith/releases/tag/desktop-v0.1.0-beta.2): macOS Apple Silicon DMG and Windows x64 NSIS, embedding the stable `0.4.0` CLI sidecar. No developer signing, no auto-update, no Linux GUI.
+1. **Conservative: stable CLI.** Use the complete ZIP / Tarball from the [latest stable Release](https://github.com/Jia-Ethan/grok-keysmith/releases/latest) (currently `v0.4.1`), or check out the same tag. `run` and `breaktest` require sibling modules, so do not download only `grok-keysmith.py` or install from floating `main`.
+2. **Easier: unsigned Desktop Beta.** See [desktop-v0.1.0-beta.3](https://github.com/Jia-Ethan/grok-keysmith/releases/tag/desktop-v0.1.0-beta.3): macOS Apple Silicon DMG and Windows x64 NSIS, embedding the stable `0.4.1` CLI sidecar. No developer signing, no auto-update, no Linux GUI.
 
 ### Quick start
 
 **Release ZIP (recommended):**
 
 ```bash
-curl -LO https://github.com/Jia-Ethan/grok-keysmith/releases/download/v0.4.0/grok-keysmith-v0.4.0.zip
-curl -LO https://github.com/Jia-Ethan/grok-keysmith/releases/download/v0.4.0/SHA256SUMS
-grep ' grok-keysmith-v0.4.0.zip$' SHA256SUMS | shasum -a 256 -c -
-unzip grok-keysmith-v0.4.0.zip
-cd grok-keysmith-v0.4.0
+curl -LO https://github.com/Jia-Ethan/grok-keysmith/releases/download/v0.4.1/grok-keysmith-v0.4.1.zip
+curl -LO https://github.com/Jia-Ethan/grok-keysmith/releases/download/v0.4.1/SHA256SUMS
+grep ' grok-keysmith-v0.4.1.zip$' SHA256SUMS | shasum -a 256 -c -
+unzip grok-keysmith-v0.4.1.zip
+cd grok-keysmith-v0.4.1
 python3 grok-keysmith.py --version
 python3 grok-keysmith.py --status
 python3 grok-keysmith.py --dry-run
@@ -64,7 +64,7 @@ python3 grok-keysmith.py --yes
 **Pinned source tag:**
 
 ```bash
-git clone --branch v0.4.0 --depth 1 https://github.com/Jia-Ethan/grok-keysmith.git
+git clone --branch v0.4.1 --depth 1 https://github.com/Jia-Ethan/grok-keysmith.git
 cd grok-keysmith
 python3 grok-keysmith.py --version
 python3 grok-keysmith.py --status
@@ -101,12 +101,12 @@ If a formatter or settings UI rewrote `config.toml` but the three `[compat.*]` t
 
 - CLI CI covers macOS / Linux / Windows; Python 3.8+. Windows `override` / `ab` need a native `grok.exe`.
 - Desktop: macOS Apple Silicon and Windows x64 only; unsigned.
-- Versions and assets live on [Releases](https://github.com/Jia-Ethan/grok-keysmith/releases). `v0.4.0` provides `--json`, `--grok-dir`, `run`, and `breaktest`. This tree is `0.4.1` (untagged) and adds `--reconcile`.
+- Versions and assets live on [Releases](https://github.com/Jia-Ethan/grok-keysmith/releases). `v0.4.1` provides `--json`, `--grok-dir`, `run`, `breaktest`, and `--reconcile`.
 
 ### Advanced docs
 
 - Compat / hooks / recovery: [`docs/reference.md`](docs/reference.md)
-- Desktop: [`gui/README.md`](gui/README.md) · [`docs/releases/desktop-v0.1.0-beta.2.md`](docs/releases/desktop-v0.1.0-beta.2.md)
+- Desktop: [`gui/README.md`](gui/README.md) · [`docs/releases/desktop-v0.1.0-beta.3.md`](docs/releases/desktop-v0.1.0-beta.3.md)
 - Agent install: [`docs/agent-install.md`](docs/agent-install.md)
 
 ### Contributing, security, and the series

--- a/README.md
+++ b/README.md
@@ -41,19 +41,19 @@ Keysmith 系列为本地 AI 工具**安全部署、验证和撤销**自定义指
 
 ### 安装方式
 
-1. **稳妥：稳定 CLI。** 使用 [最新稳定 Release](https://github.com/Jia-Ethan/grok-keysmith/releases/latest)（当前 `v0.4.0`）的完整 ZIP / Tarball，或 checkout 同一 tag。`run` 与 `breaktest` 依赖同目录模块，不要只下载 `grok-keysmith.py`，也不要从浮动 `main` 安装。
-2. **更易用：未签名 Desktop Beta。** 见 [desktop-v0.1.0-beta.2](https://github.com/Jia-Ethan/grok-keysmith/releases/tag/desktop-v0.1.0-beta.2)：macOS Apple Silicon DMG 与 Windows x64 NSIS，内嵌稳定版 `0.4.0` CLI sidecar。无开发者签名、无自动更新、无 Linux GUI。
+1. **稳妥：稳定 CLI。** 使用 [最新稳定 Release](https://github.com/Jia-Ethan/grok-keysmith/releases/latest)（当前 `v0.4.1`）的完整 ZIP / Tarball，或 checkout 同一 tag。`run` 与 `breaktest` 依赖同目录模块，不要只下载 `grok-keysmith.py`，也不要从浮动 `main` 安装。
+2. **更易用：未签名 Desktop Beta。** 见 [desktop-v0.1.0-beta.3](https://github.com/Jia-Ethan/grok-keysmith/releases/tag/desktop-v0.1.0-beta.3)：macOS Apple Silicon DMG 与 Windows x64 NSIS，内嵌稳定版 `0.4.1` CLI sidecar。无开发者签名、无自动更新、无 Linux GUI。
 
 ### 快速开始
 
 **Release ZIP（推荐）：**
 
 ```bash
-curl -LO https://github.com/Jia-Ethan/grok-keysmith/releases/download/v0.4.0/grok-keysmith-v0.4.0.zip
-curl -LO https://github.com/Jia-Ethan/grok-keysmith/releases/download/v0.4.0/SHA256SUMS
-grep ' grok-keysmith-v0.4.0.zip$' SHA256SUMS | shasum -a 256 -c -
-unzip grok-keysmith-v0.4.0.zip
-cd grok-keysmith-v0.4.0
+curl -LO https://github.com/Jia-Ethan/grok-keysmith/releases/download/v0.4.1/grok-keysmith-v0.4.1.zip
+curl -LO https://github.com/Jia-Ethan/grok-keysmith/releases/download/v0.4.1/SHA256SUMS
+grep ' grok-keysmith-v0.4.1.zip$' SHA256SUMS | shasum -a 256 -c -
+unzip grok-keysmith-v0.4.1.zip
+cd grok-keysmith-v0.4.1
 python3 grok-keysmith.py --version
 python3 grok-keysmith.py --status
 python3 grok-keysmith.py --dry-run
@@ -64,7 +64,7 @@ python3 grok-keysmith.py --yes
 **固定 tag 源码：**
 
 ```bash
-git clone --branch v0.4.0 --depth 1 https://github.com/Jia-Ethan/grok-keysmith.git
+git clone --branch v0.4.1 --depth 1 https://github.com/Jia-Ethan/grok-keysmith.git
 cd grok-keysmith
 python3 grok-keysmith.py --version
 python3 grok-keysmith.py --status
@@ -101,12 +101,12 @@ formatter 或设置页重写了 `config.toml`、三组 `[compat.*]` 取值仍完
 
 - CLI CI 覆盖 macOS / Linux / Windows；Python 3.8+。Windows 上 `override` / `ab` 需要原生 `grok.exe`。
 - Desktop：仅 macOS Apple Silicon 与 Windows x64，未签名。
-- 版本、资产和签名以 [Releases](https://github.com/Jia-Ethan/grok-keysmith/releases) 为准。`v0.4.0` 提供 `--json`、`--grok-dir`、`run` 与 `breaktest`。本仓库当前代码是 `0.4.1`（尚未打 tag），增加 `--reconcile`。
+- 版本、资产和签名以 [Releases](https://github.com/Jia-Ethan/grok-keysmith/releases) 为准。`v0.4.1` 提供 `--json`、`--grok-dir`、`run`、`breaktest` 与 `--reconcile`。
 
 ### 进阶文档
 
 - Compat / hooks / 恢复：[`docs/reference.md`](docs/reference.md)
-- Desktop：[`gui/README.md`](gui/README.md) · [`docs/releases/desktop-v0.1.0-beta.2.md`](docs/releases/desktop-v0.1.0-beta.2.md)
+- Desktop：[`gui/README.md`](gui/README.md) · [`docs/releases/desktop-v0.1.0-beta.3.md`](docs/releases/desktop-v0.1.0-beta.3.md)
 - 智能体安装：[`docs/agent-install.md`](docs/agent-install.md)
 
 ### 贡献、安全与系列

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -3,5 +3,5 @@
 # 复制给智能体安装 / Copy this to an agent
 
 ```text
-请从公开仓库安装 grok-keysmith v0.4.0。只使用签名 annotated tag `v0.4.0` 或对应 GitHub Release,不要从浮动 `main` 安装;检出后确认当前 checkout 精确匹配 `v0.4.0` tag,并校验 examples/grok-unrestricted.md 的 SHA-256 为 `d693411fd79f57c5e805e7bcbb27b42bacdd11e6a6af8858ab998017196dc898`。运行 --version、--status 和 --dry-run,报告目标 ~/.grok 目录、内置提示词来源与 SHA-256、全局行为范围、compat 隔离计划、hooks 隔离计划和备份路径;如果 status 发现 durable journal,只预览 --recover 并等我确认后才添加 --yes。完成后开启新 Grok 会话,验证 ~/.grok/rules/99-keysmith.md 已加载、Claude/Cursor 全部 compatibility surface 为 OFF,且 Codex sessions 为 OFF;确认 ~/.grok/AGENTS.md 未被改动。不要删除任何备份或事务日志,不修改 Grok 二进制、网络、运行中进程或凭证。
+请从公开仓库安装 grok-keysmith v0.4.1。只使用签名 annotated tag `v0.4.1` 或对应 GitHub Release,不要从浮动 `main` 安装;检出后确认当前 checkout 精确匹配 `v0.4.1` tag,并校验 examples/grok-unrestricted.md 的 SHA-256 为 `d693411fd79f57c5e805e7bcbb27b42bacdd11e6a6af8858ab998017196dc898`。运行 --version、--status 和 --dry-run,报告目标 ~/.grok 目录、内置提示词来源与 SHA-256、全局行为范围、compat 隔离计划、hooks 隔离计划和备份路径;如果 status 发现 durable journal,只预览 --recover 并等我确认后才添加 --yes。完成后开启新 Grok 会话,验证 ~/.grok/rules/99-keysmith.md 已加载、Claude/Cursor 全部 compatibility surface 为 OFF,且 Codex sessions 为 OFF;确认 ~/.grok/AGENTS.md 未被改动。不要删除任何备份或事务日志,不修改 Grok 二进制、网络、运行中进程或凭证。
 ```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -12,8 +12,8 @@
 
 ### 稳定 CLI 与开发版
 
-- 稳妥安装钉 GitHub Latest 稳定 Release（当前为 `v0.4.0`）。该版本把指令写到 `~/.grok/rules/99-keysmith.md`，**不改** `~/.grok/AGENTS.md`，并提供 `--json`、绝对路径 `--grok-dir`、`run` 与 `breaktest`。
-- 不要从浮动 `main` 安装稳定版。Desktop `0.1.0-beta.2` 是未签名预发布版本，内嵌稳定版 CLI `0.4.0`。
+- 稳妥安装钉 GitHub Latest 稳定 Release（当前为 `v0.4.1`）。该版本把指令写到 `~/.grok/rules/99-keysmith.md`，**不改** `~/.grok/AGENTS.md`，并提供 `--json`、绝对路径 `--grok-dir`、`run`、`breaktest` 与 `--reconcile`。
+- 不要从浮动 `main` 安装稳定版。Desktop `0.1.0-beta.3` 是未签名预发布版本，内嵌稳定版 CLI `0.4.1`。
 
 ### 状态输出
 
@@ -146,7 +146,7 @@ for document in (
     "README.en.md",
     "CHANGELOG.md",
     "SECURITY.md",
-    "docs/releases/desktop-v0.1.0-beta.2.md",
+    "docs/releases/desktop-v0.1.0-beta.3.md",
 ):
     assert version in Path(document).read_text(encoding="utf-8")
 assert bundled == prompt
@@ -173,7 +173,7 @@ grok-keysmith/
 ├── grok-unrestricted.sh/.ps1     # Runner 包装
 ├── examples/grok-unrestricted.md
 ├── tests/                        # 隔离 HOME / fake Grok 测试
-├── gui/                          # Desktop 0.1.0-beta.2
+├── gui/                          # Desktop 0.1.0-beta.3
 ├── VERSION
 ├── docs/
 ├── README.md / README.en.md
@@ -198,8 +198,8 @@ grok-keysmith/
 
 ### Stable CLI vs development
 
-- The conservative install pins the latest stable GitHub Release (currently `v0.4.0`). It writes `~/.grok/rules/99-keysmith.md`, **does not** edit `~/.grok/AGENTS.md`, and provides `--json`, absolute `--grok-dir`, `run`, and `breaktest`.
-- Do not install a stable release from floating `main`. Desktop `0.1.0-beta.2` is an unsigned pre-release that embeds stable CLI `0.4.0`.
+- The conservative install pins the latest stable GitHub Release (currently `v0.4.1`). It writes `~/.grok/rules/99-keysmith.md`, **does not** edit `~/.grok/AGENTS.md`, and provides `--json`, absolute `--grok-dir`, `run`, `breaktest`, and `--reconcile`.
+- Do not install a stable release from floating `main`. Desktop `0.1.0-beta.3` is an unsigned pre-release that embeds stable CLI `0.4.1`.
 
 ### Status output
 

--- a/docs/releases/desktop-v0.1.0-beta.3.md
+++ b/docs/releases/desktop-v0.1.0-beta.3.md
@@ -1,0 +1,30 @@
+# Desktop v0.1.0-beta.3
+
+Published on 2026-08-18 as the GitHub pre-release [`desktop-v0.1.0-beta.3`](https://github.com/Jia-Ethan/grok-keysmith/releases/tag/desktop-v0.1.0-beta.3). Both packages are built from the exact release tag target and bundle CLI `0.4.1`.
+
+- Product: `grok-keysmith`
+- Package: `grok-keysmith-gui`
+- Identifier: `com.jia-ethan.grok-keysmith-gui`
+- Sidecar: `grok-keysmith-cli`
+- CLI version bundled: `0.4.1`
+- macOS: Apple Silicon DMG with an ad-hoc app signature; no Apple Developer ID or notarization
+- Windows: x64 current-user NSIS installer without Authenticode
+
+## Published assets
+
+| Host | Artifact |
+| --- | --- |
+| macOS Apple Silicon | [`grok-keysmith_0.1.0-beta.3_aarch64.dmg`](https://github.com/Jia-Ethan/grok-keysmith/releases/download/desktop-v0.1.0-beta.3/grok-keysmith_0.1.0-beta.3_aarch64.dmg) |
+| Windows x64 | [`grok-keysmith_0.1.0-beta.3_x64-setup.exe`](https://github.com/Jia-Ethan/grok-keysmith/releases/download/desktop-v0.1.0-beta.3/grok-keysmith_0.1.0-beta.3_x64-setup.exe) |
+
+The Release also publishes [`SHA256SUMS`](https://github.com/Jia-Ethan/grok-keysmith/releases/download/desktop-v0.1.0-beta.3/SHA256SUMS). Verify downloaded assets against that file before opening them.
+
+## Product boundary
+
+Top-level navigation contains Status, Deploy, Manage, and Settings. Run and Test remain available through opt-in Advanced tools, and legacy deep links continue to resolve. Primary status, preview, error, and diagnostics surfaces use user-facing summaries with technical details on demand.
+
+Write actions stay fail closed around managed ownership, hook ownership, drift or conflict, and interrupted transactions. Repairable marker or serialization drift exposes only the preview-confirm reconcile path. Preview binding, exclusive operation leases, post-write verification, and recursive local-path redaction remain part of the desktop boundary.
+
+## Safety
+
+All writes go through the bundled CLI. Automated tests use isolated directories and a fake Grok executable; candidate builds do not call a real model or read the operator's `~/.grok`.

--- a/gui/README.md
+++ b/gui/README.md
@@ -1,9 +1,9 @@
 # grok-keysmith desktop
 
-Version `0.1.0-beta.2` is the published release at [`desktop-v0.1.0-beta.2`](https://github.com/Jia-Ethan/grok-keysmith/releases/tag/desktop-v0.1.0-beta.2). The current source tree is the unreleased `0.1.0-beta.3` prerelease. The published Release provides an ad-hoc-signed macOS Apple Silicon DMG, an unsigned Windows x64 current-user NSIS installer, and `SHA256SUMS`.
+Version `0.1.0-beta.3` is published as [`desktop-v0.1.0-beta.3`](https://github.com/Jia-Ethan/grok-keysmith/releases/tag/desktop-v0.1.0-beta.3). The Release provides an ad-hoc-signed macOS Apple Silicon DMG, an unsigned Windows x64 current-user NSIS installer, and `SHA256SUMS`.
 
-- macOS: `grok-keysmith_0.1.0-beta.2_aarch64.dmg`
-- Windows: `grok-keysmith_0.1.0-beta.2_x64-setup.exe`
+- macOS: `grok-keysmith_0.1.0-beta.3_aarch64.dmg`
+- Windows: `grok-keysmith_0.1.0-beta.3_x64-setup.exe`
 
 Top-level navigation focuses on Status, Deploy, Manage, and Settings. Run and Test live under opt-in Advanced tools; primary surfaces show user summaries with technical details on demand. Write actions remain gated by managed ownership, drift/conflict, interrupted-transaction state, fresh preview binding, and post-write verification. Repairable marker/serialization drift exposes only the dedicated Manage action (`--reconcile`), not uninstall, hook restore, or interrupted-operation recovery. Reconcile always runs a fresh preview before applying with `--expected-preview-token`; it is separate from `--recover` and never consumes transaction residue.
 

--- a/gui/SPEC.md
+++ b/gui/SPEC.md
@@ -1,6 +1,6 @@
 # grok-keysmith GUI
 
-Desktop `0.1.0-beta.2` is the published release. This source tree is the unreleased `0.1.0-beta.3` prerelease and wraps the Python CLI. The UI never writes `~/.grok` itself.
+Desktop `0.1.0-beta.3` wraps the Python CLI. The UI never writes `~/.grok` itself.
 
 Stack: Tauri 2 + React 19 + Tailwind 4 + Radix + Motion + PyInstaller sidecar `grok-keysmith-cli`.
 


### PR DESCRIPTION
## 改动

- 将 CLI 版本正式化为 0.4.1，并同步稳定安装与完整性边界
- 将 Desktop 版本升级为 0.1.0-beta.3
- 保留既有 tag、Release 和资产不变

## 验证

- 版本与提示词完整性检查通过
- `git diff --check`